### PR TITLE
Flexible initial conditions input

### DIFF
--- a/docs/configure.md
+++ b/docs/configure.md
@@ -422,6 +422,7 @@ The tables below give an exhaustive list of all of the different HYDRAD configur
 | tabulated_gravity_profile | Coefficients (in order of increasing exponent) for 6th order polynomial fit to the field-aligned gravitational acceleration | array-like | |
 | tabulated_cross_section_profile | Coefficients (in order of increasing exponent) for 6th order polynomial fit to the field-aligned gravitational acceleration | array-like | |
 | logging_frequency | Frequency (in number of timesteps) that progress is printed to the screen | `int` | |
+| initial_amr_file | Adaptive mesh file to initialize loop from; if not given, uses the result from the initial conditions code | `str` | |
 | write_file_physical | Toggle writing `.phy` solutions file | `bool` | |
 | write_file_ion_populations | Toggle writing `.ine` file | `bool` | |
 | write_file_hydrogen_level_populations | Toggle writing `.Hstate` file | `bool` | |
@@ -441,12 +442,12 @@ The tables below give an exhaustive list of all of the different HYDRAD configur
 |:----:|:------------|:----:|:-----|
 | use_tabulated_gravity | If true, read gravitational profile from file | `bool` | |
 | footpoint_temperature | Temperature at the loop footpoint | `float` | K
-| footpoint_density | Density at the loop footpoint | `float` | cm<sup>-3</sup>|
+| footpoint_density | Density at the loop footpoint | `float` | cm$^{-3}$|
 | heating_location | Loop coordinate where equilibrium heat is injected | `float` | cm |
 | heating_scale_height | Spatial scale of the injected equilibrium heating | `float` | cm |
 | isothermal | If true, inital temperature profile is uniform | `bool` | |
-| heating_range_lower_bound | Lower bound on rate search range| `float` |$\mathrm{erg}\,\mathrm{cm}^{-3}\,\mathrm{s}^{-1}$ |
-| heating_range_upper_bound | Upper bound on rate search range| `float` |$\mathrm{erg}\,\mathrm{cm}^{-3}\,\mathrm{s}^{-1}$  |
+| heating_range_lower_bound | Lower bound on rate search range| `float` | $\mathrm{erg}\,\mathrm{cm}^{-3}\,\mathrm{s}^{-1}$  |
+| heating_range_upper_bound | Upper bound on rate search range| `float` | $\mathrm{erg}\,\mathrm{cm}^{-3}\,\mathrm{s}^{-1}$  |
 | heating_range_step_size | Resolution of heating search range | `float` | |
 | heating_range_fine_tuning | | `float` | |
 

--- a/hydrad_tools/configure/configure.py
+++ b/hydrad_tools/configure/configure.py
@@ -74,7 +74,8 @@ class Configure(object):
         """
         asdf.AsdfFile(self.config).write_to(filename)
     
-    def setup_simulation(self, output_path, base_path=None, name=None, verbose=True):
+    def setup_simulation(self, output_path, base_path=None, name=None, verbose=True,
+                         run_initial_conditions=True):
         """
         Setup a HYDRAD simulation with desired outputs from a clean copy
 
@@ -84,13 +85,15 @@ class Configure(object):
         (appropriate permissions required)
         name (`str`): Name of the output directory. If None (default), use timestamp
         verbose (`bool`):
+        run_initial_conditions (`bool`): If True, compile and run the initial conditions code
         """
         with tempfile.TemporaryDirectory() as tmpdir:
             if base_path is None:
                 git.Repo.clone_from(REMOTE_REPO, tmpdir)
             else:
                 copy_tree(base_path, tmpdir)
-            self.setup_initial_conditions(tmpdir, execute=True, verbose=verbose)
+            if run_initial_conditions:
+                self.setup_initial_conditions(tmpdir, execute=True, verbose=verbose)
             self.setup_hydrad(tmpdir, verbose=verbose)
             self.save_config(os.path.join(tmpdir, 'hydrad_tools_config.asdf'))
             if name is None:
@@ -161,6 +164,9 @@ class Configure(object):
         verbose (`bool`):
         """
         files = [
+            ('Radiation_Model/source/config.h', self.radiation_header),
+            ('Radiation_Model/config/elements_eq.cfg', self.radiation_equilibrium_cfg),
+            ('Radiation_Model/config/elements_neq.cfg', self.radiation_nonequilibrium_cfg),
             ('Heating_Model/source/config.h', self.heating_header),
             ('Heating_Model/config/heating_model.cfg', self.heating_cfg),
             ('HYDRAD/source/config.h', self.hydrad_header),

--- a/hydrad_tools/configure/templates/hydrad.cfg
+++ b/hydrad_tools/configure/templates/hydrad.cfg
@@ -1,4 +1,8 @@
+{% if general.initial_amr_file -%}
+{{ general.initial_amr_file }}
+{%- else -%}
 Initial_Conditions/profiles/initial.amr
+{%- endif %}
 {% if general.tabulated_gravity_file -%}
 {{ general.tabulated_gravity_file }}
 {%- else -%}


### PR DESCRIPTION
Allow for other AMR files to serve as the starting condition for HYDRAD. This may also be useful when checkpointing long-running simulations

Make compiling and running IC code optional.

Doc updates to reflect these changes.