### PR TITLE
Fix bug in importing config from ASDF

### DIFF
--- a/hydrad_tools/configure/configure.py
+++ b/hydrad_tools/configure/configure.py
@@ -62,7 +62,7 @@ class Configure(object):
         filename (`str`): Path to ASDF configuration file
         """
         with asdf.open(filename) as af:
-            config = af.tree
+            config = copy.deepcopy(dict(af.tree))
         return config
 
     def save_config(self, filename):


### PR DESCRIPTION
Fixes a bug where asdf would throw an OSError when we deepcopied the loaded-in config later on. For some reason it was hanging on to a reference to the (closed) file instead of just being a dict.