### PR TITLE
Fixes a bug in deriving the electron pressure from conserved quantities in AMR files

### DIFF
--- a/pydrad/configure/configure.py
+++ b/pydrad/configure/configure.py
@@ -12,7 +12,6 @@ import shutil
 import stat
 import tempfile
 
-from distutils.dir_util import copy_tree
 from jinja2 import ChoiceLoader, DictLoader, Environment, PackageLoader
 
 from pydrad.configure import filters
@@ -101,7 +100,7 @@ class Configure:
         with tempfile.TemporaryDirectory() as tmpdir:
             # NOTE: this is all done in a temp directory and then copied over
             # so that if something fails, all the files are cleaned up
-            copy_tree(base_path, tmpdir)
+            shutil.copytree(base_path, tmpdir)
             if run_initial_conditions:
                 execute = kwargs.get('execute', True)
                 self.setup_initial_conditions(tmpdir, execute=execute)

--- a/pydrad/configure/configure.py
+++ b/pydrad/configure/configure.py
@@ -100,7 +100,7 @@ class Configure:
         with tempfile.TemporaryDirectory() as tmpdir:
             # NOTE: this is all done in a temp directory and then copied over
             # so that if something fails, all the files are cleaned up
-            shutil.copytree(base_path, tmpdir)
+            shutil.copytree(base_path, tmpdir, dirs_exist_ok=True)
             if run_initial_conditions:
                 execute = kwargs.get('execute', True)
                 self.setup_initial_conditions(tmpdir, execute=execute)

--- a/pydrad/parse/parse.py
+++ b/pydrad/parse/parse.py
@@ -547,7 +547,7 @@ Timestep #: {self._index}"""
         """
         if hasattr(self, '_phy_data'):
             return self._phy_data['electron_pressure']
-        return self.electron_energy_density / (pydrad.util.constants.gamma - 1)
+        return self.electron_energy_density * (pydrad.util.constants.gamma - 1)
 
     @property
     @u.quantity_input

--- a/pydrad/parse/tests/test_strand.py
+++ b/pydrad/parse/tests/test_strand.py
@@ -237,4 +237,13 @@ def test_ine_results(strand):
 def test_phy_amr_consistency(property, strand_only_amr, strand_phy):
     # Check consistency between properties derived from different file types
     for p_amr,p_phy in zip(strand_only_amr, strand_phy):
-        assert u.allclose(getattr(p_amr, property), getattr(p_phy, property), rtol=5e-3)
+        assert u.allclose(getattr(p_amr, property), getattr(p_phy, property), rtol=5e-4)
+
+
+def test_electron_hydrogen_initial_equilibrium(strand_only_amr, strand_phy):
+    # The electron and hydrogen temperatures should be the same at the first
+    # timestep because no heating has occurred to drive them out of equilibrium.
+    assert u.allclose(strand_only_amr[0].electron_temperature,
+                      strand_only_amr[0].hydrogen_temperature)
+    assert u.allclose(strand_phy[0].electron_temperature,
+                      strand_phy[0].hydrogen_temperature)

--- a/pydrad/parse/tests/test_strand.py
+++ b/pydrad/parse/tests/test_strand.py
@@ -80,6 +80,16 @@ def strand_only_amr(hydrad):
                   read_scl=False)
 
 
+@pytest.fixture
+def strand_phy(hydrad):
+    return Strand(hydrad,
+                  read_phy=True,
+                  read_ine=False,
+                  read_trm=False,
+                  read_hstate=False,
+                  read_scl=False)
+
+
 def test_parse_initial_conditions(strand):
     assert hasattr(strand, 'initial_conditions')
 
@@ -213,3 +223,18 @@ def test_ine_results(strand):
                 assert hasattr(profile, f'{element}_{i_z}')
                 ion_frac = getattr(profile, f'{element}_{i_z}')
                 assert ion_frac.shape == profile.coordinate.shape
+
+
+@pytest.mark.parametrize('property',[
+        'velocity',
+        'hydrogen_density',
+        'electron_density',
+        'electron_pressure',
+        'hydrogen_pressure',
+        'electron_temperature',
+        'hydrogen_temperature',
+])
+def test_phy_amr_consistency(property, strand_only_amr, strand_phy):
+    # Check consistency between properties derived from different file types
+    for p_amr,p_phy in zip(strand_only_amr, strand_phy):
+        assert u.allclose(getattr(p_amr, property), getattr(p_phy, property), rtol=5e-3)


### PR DESCRIPTION
This fixes a bug in how the electron pressure is calculated from the conserved quantities calculated in the `amr` files. I was dividing by $\gamma - 1$ instead of multiplying so in cases where only the `amr` files were being used, the electron temperature was off by over a factor of 2. 🤦 

This also includes several tests to ensure this doesn't happen again.